### PR TITLE
Generalize target triple

### DIFF
--- a/src/AVRCompiler.jl
+++ b/src/AVRCompiler.jl
@@ -9,7 +9,7 @@ using LLVM
 
 struct Arduino <: GPUCompiler.AbstractCompilerTarget end
 
-GPUCompiler.llvm_triple(::Arduino) = "avr-unknown-unkown"
+GPUCompiler.llvm_triple(::Arduino) = "thumbv7em-none-unknown-eabihf"
 GPUCompiler.runtime_slug(j::GPUCompiler.CompilerJob{Arduino}) = j.params.name
 
 struct ArduinoParams <: GPUCompiler.AbstractCompilerParams


### PR DESCRIPTION
There isn't that much Arduino-specific to this package, so by making the target triple a parameter, you can use it for basically any LLVM target you want.